### PR TITLE
docs(readme): correct typo of `fuel-sever` to `fuel-server`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,31 @@ This server indexes Fuel and Sway documentation (including markdown files) into 
 - qdrant db can be hosted for remote LLMs
 - Contains the scripts to index new docs
 
-## Quick Install
+## Quick Start
 
+1. **Clone source**
 ```bash
-# Git clone the repo
 git clone --depth 1 https://github.com/FuelLabs/fuel-mcp-server
+```
 
-# Docker compose
+2. **Run containers**
+```bash
 docker compose -f fuel-mcp-server/docker-compose.yml up -d
+```
 
-# Copy this
+3. **To provide cursor with the resolved path, copy the output of the following command:**
+```bash
 realpath fuel-mcp-server
 ```
 
-Edit your Cursor `mcp.json`
+The output may be something like:
+
+```
+/home/yourname/workspace/fuel-mcp-server
+```
+
+4. **Edit your Cursor `mcp.json`**
+
 ```json
 {
   "mcpServers": {

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Fuel Network & Sway Language MCP Server
 
-This project provides a Multi-Component Protocol (MCP) server specifically designed for the Fuel Network and Sway Language ecosystem. It allows IDEs (like VS Code with the appropriate extension) to connect and seamlessly interact with Fuel documentation, enabling easier searching, understanding, and development within Fuel projects.
+This project provides a Multi-Component Protocol (MCP) server specifically designed for the [Fuel Network](https://fuel.network) and [Sway Language](https://docs.fuel.network/docs/sway/) ecosystem. It allows IDEs (like VS Code with the appropriate extension) to connect and seamlessly interact with Fuel documentation, enabling easier searching, understanding, and development within Fuel projects.
 
 This server indexes Fuel and Sway documentation (including markdown files) into a Qdrant vector database using open-source embeddings (via Transformers.js). This allows for powerful semantic search capabilities directly within the development environment.
 
 ## Features
-- Makes the entire docs.fuel.network content locally searchable to agents
+- Makes the entire [docs.fuel.network](https://docs.fuel.network/docs/intro/what-is-fuel/) content locally searchable to agents
 - Hybrid search (RAG + keyword via qdrant)
 - qdrant db can be hosted for remote LLMs
 - Contains the scripts to index new docs

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Edit your Cursor `mcp.json`
 ```json
 {
   "mcpServers": {
-    "fuel-sever": {
+    "fuel-server": {
       "command": "docker",
       "args": [
         "compose",
@@ -122,7 +122,7 @@ This project includes a `docker-compose.yml` file to easily run both the Qdrant 
     ```json
     {
       "mcpServers": {
-        "fuel-sever": {
+        "fuel-server": {
           "command": "docker",
           "args": [
             "compose",


### PR DESCRIPTION
Closes #1

# Key Changes

- Correct typo

| Before | After |
|-|-|
| ![image](https://github.com/user-attachments/assets/4b67be64-0c24-4170-8d64-91d73aedc3de) | ![image](https://github.com/user-attachments/assets/ae9911b9-d6ef-4c47-b121-5671dd73c4de) |

## Additional improvements
- Add hyperlinks

| Before | After |
|-|-|
| ![image](https://github.com/user-attachments/assets/0404a7c7-38ba-4cd1-be56-210d3e8ee27c) | ![image](https://github.com/user-attachments/assets/f2ade95b-7876-4bca-a7cd-73d695d3cb0c) |

- Improve phrasing to be more terse, as the code speaks for itself

| Before | After |
|-|-|
| ![image](https://github.com/user-attachments/assets/031068f4-5342-4c01-9a39-896996502a9d) | ![image](https://github.com/user-attachments/assets/75b2630b-25a4-4bc3-bf45-2ecf3c5a2ecd) |

## Suggestions
 - Include this MCP server as part of the [Sway LSP](https://github.com/FuelLabs/sway/tree/master/sway-lsp)
 - Auto-sync with the actual [Fuel Docs](https://github.com/FuelLabs/docs-hub).
   - Otherwise the server risks providing out-of-date information, thus destroying the MCP experience.
 - Use [Nix](https://nixos.org) to automate environment setup and reduce grunt work of copy-pasting shell commands.